### PR TITLE
[MOD-70][MOD-116][Feature] Update DOI mint behavior for moderation submissions

### DIFF
--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -1,6 +1,5 @@
 import pytest
 import mock
-from nose.tools import assert_false, assert_true
 
 from api.base.settings.defaults import API_BASE
 
@@ -226,12 +225,12 @@ class TestActionCreate(object):
                 if preprint.in_public_reviews_state:
                     assert preprint.is_published
                     assert preprint.date_published == action.date_created
-                    assert_true(mock_ezid.called)
+                    assert mock_ezid.called
                     mock_ezid.reset_mock()
                 else:
                     assert not preprint.is_published
                     assert preprint.date_published is None
-                    assert_false(mock_ezid.called)
+                    assert not mock_ezid.called
 
                 if trigger == 'edit_comment':
                     assert preprint.date_last_transitioned is None

--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -1,5 +1,6 @@
 import pytest
 import mock
+from nose.tools import assert_false, assert_true
 
 from api.base.settings.defaults import API_BASE
 
@@ -225,15 +226,14 @@ class TestActionCreate(object):
                 if preprint.in_public_reviews_state:
                     assert preprint.is_published
                     assert preprint.date_published == action.date_created
+                    assert_true(mock_ezid.called)
+                    mock_ezid.reset_mock()
                 else:
                     assert not preprint.is_published
                     assert preprint.date_published is None
+                    assert_false(mock_ezid.called)
 
                 if trigger == 'edit_comment':
                     assert preprint.date_last_transitioned is None
                 else:
                     assert preprint.date_last_transitioned == action.date_created
-
-        # Check if total 8 calls to "get_and_set_preprint_identifiers". The preprint went through total 5 post_moderation in_public_reviews_state
-        # (3 accepted and 2 pending states) and 3 pre_moderation in_public_reviews_state (accepted states).
-        assert mock_ezid.call_count == 8

--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -1,4 +1,5 @@
 import pytest
+import mock
 
 from api.base.settings.defaults import API_BASE
 
@@ -72,7 +73,8 @@ class TestActionCreate(object):
         moderator.groups.add(GroupHelper(provider).get_group('moderator'))
         return moderator
 
-    def test_create_permissions(self, app, url, preprint, node_admin, moderator):
+    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
+    def test_create_permissions(self, mock_ezid, app, url, preprint, node_admin, moderator):
         assert preprint.reviews_state == 'initial'
 
         submit_payload = self.create_payload(preprint._id, trigger='submit')
@@ -125,6 +127,9 @@ class TestActionCreate(object):
         assert preprint.reviews_state == 'accepted'
         assert preprint.is_published
 
+        # Check if "get_and_set_preprint_identifiers" is called once.
+        assert mock_ezid.call_count == 1
+
     def test_cannot_create_actions_for_unmoderated_provider(self, app, url, preprint, provider, node_admin):
         provider.reviews_workflow = None
         provider.save()
@@ -173,7 +178,8 @@ class TestActionCreate(object):
         res = app.post_json_api(url, bad_payload, auth=moderator.auth, expect_errors=True)
         assert res.status_code == 400
 
-    def test_valid_transitions(self, app, url, preprint, provider, moderator):
+    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
+    def test_valid_transitions(self, mock_ezid, app, url, preprint, provider, moderator):
         valid_transitions = {
             'post-moderation': [
                 ('accepted', 'edit_comment', 'accepted'),
@@ -227,3 +233,7 @@ class TestActionCreate(object):
                     assert preprint.date_last_transitioned is None
                 else:
                     assert preprint.date_last_transitioned == action.date_created
+
+        # Check if total 8 calls to "get_and_set_preprint_identifiers". The preprint went through total 5 post_moderation in_public_reviews_state
+        # (3 accepted and 2 pending states) and 3 pre_moderation in_public_reviews_state (accepted states).
+        assert mock_ezid.call_count == 8

--- a/osf/models/nodelog.py
+++ b/osf/models/nodelog.py
@@ -115,8 +115,6 @@ class NodeLog(ObjectIDMixin, BaseModel):
     PREPRINT_INITIATED = 'preprint_initiated'
     PREPRINT_FILE_UPDATED = 'preprint_file_updated'
     PREPRINT_LICENSE_UPDATED = 'preprint_license_updated'
-    PREPRINT_PUBLISHED = 'preprint_published'
-    PREPRINT_UNPUBLISHED = 'preprint_unpublished'
 
     VIEW_ONLY_LINK_ADDED = 'view_only_link_added'
     VIEW_ONLY_LINK_REMOVED = 'view_only_link_removed'

--- a/osf/models/nodelog.py
+++ b/osf/models/nodelog.py
@@ -115,6 +115,9 @@ class NodeLog(ObjectIDMixin, BaseModel):
     PREPRINT_INITIATED = 'preprint_initiated'
     PREPRINT_FILE_UPDATED = 'preprint_file_updated'
     PREPRINT_LICENSE_UPDATED = 'preprint_license_updated'
+    PREPRINT_PUBLISHED = 'preprint_published'
+    PREPRINT_UNPUBLISHED = 'preprint_unpublished'
+
 
     VIEW_ONLY_LINK_ADDED = 'view_only_link_added'
     VIEW_ONLY_LINK_REMOVED = 'view_only_link_removed'

--- a/osf/models/nodelog.py
+++ b/osf/models/nodelog.py
@@ -118,7 +118,6 @@ class NodeLog(ObjectIDMixin, BaseModel):
     PREPRINT_PUBLISHED = 'preprint_published'
     PREPRINT_UNPUBLISHED = 'preprint_unpublished'
 
-
     VIEW_ONLY_LINK_ADDED = 'view_only_link_added'
     VIEW_ONLY_LINK_REMOVED = 'view_only_link_removed'
 

--- a/reviews/models/mixins.py
+++ b/reviews/models/mixins.py
@@ -188,7 +188,7 @@ class ReviewsMachine(Machine):
             self.reviewable.is_published = True
 
             self.reviewable.node.add_log(
-                action=NodeLog.PREPRINT_PUBLISHED + '_' + self.reviewable.provider.reviews_workflow,
+                action=NodeLog.PREPRINT_INITIATED,
                 params={
                     'preprint': self.reviewable._id
                 },
@@ -197,14 +197,6 @@ class ReviewsMachine(Machine):
             )
             enqueue_postcommit_task(get_and_set_preprint_identifiers, (), {'preprint': self.reviewable}, celery=True)
         elif not should_publish and self.reviewable.is_published:
-            self.reviewable.node.add_log(
-                action=NodeLog.PREPRINT_UNPUBLISHED + '_' + self.reviewable.provider.reviews_workflow,
-                params={
-                    'preprint': self.reviewable._id
-                },
-                auth=auth,
-                save=False,
-            )
             self.reviewable.is_published = False
         self.reviewable.save()
 

--- a/reviews/models/mixins.py
+++ b/reviews/models/mixins.py
@@ -174,8 +174,7 @@ class ReviewsMachine(Machine):
     def save_changes(self, ev):
         now = self.action.date_created if self.action is not None else timezone.now()
         should_publish = self.reviewable.in_public_reviews_state
-        to_state = ev.state.name
-        if should_publish and not self.reviewable.is_published and to_state == workflow.States.ACCEPTED.value:
+        if should_publish and not self.reviewable.is_published:
             if not (self.reviewable.node.preprint_file and self.reviewable.node.preprint_file.node == self.reviewable.node):
                 raise ValueError('Preprint node is not a valid preprint; cannot publish.')
             if not self.reviewable.provider:

--- a/reviews/models/mixins.py
+++ b/reviews/models/mixins.py
@@ -186,7 +186,7 @@ class ReviewsMachine(Machine):
             self.reviewable.node._has_abandoned_preprint = False
             self.reviewable.is_published = True
             user = ev.kwargs.get('user')
-            auth=Auth(user)
+            auth = Auth(user)
             self.reviewable.node.add_log(
                 action=NodeLog.PREPRINT_INITIATED,
                 params={


### PR DESCRIPTION
## Purpose
We mint DOIs when preprints are submitted as part of the current submission workflow. We are adding 2 moderation workflows, pre-moderation and post-moderation, and we should update the current workflow to add DOI minting.

## Changes

Update save_changes inside ReviewsMachine to create EZID identifier.


## Side effects

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/MOD-70